### PR TITLE
Wstępna implementacja gry Tratwa

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # tratwa
+
+Prototyp gry mobilnej **"Tratwa"** zbudowany w Flutter z wykorzystaniem biblioteki Flame.
+
+## Uruchomienie
+
+1. Zainstaluj [Flutter](https://flutter.dev) oraz zaleznosci.
+2. Pobierz paczki:
+   ```bash
+   flutter pub get
+   ```
+3. Uruchom gre:
+   ```bash
+   flutter run
+   ```
+
+Aplikacja przedstawia podstawy etapu 1: okragly ocean z wyspa, ruch tratwy w 8 kierunkach oraz minimape w lewym dolnym rogu.

--- a/lib/game/tratwa_game.dart
+++ b/lib/game/tratwa_game.dart
@@ -1,0 +1,30 @@
+import 'package:flame/components.dart';
+import 'package:flame/game.dart';
+import '../world/ocean.dart';
+import '../world/raft.dart';
+import '../ui/minimap.dart';
+
+/// Glowna klasa gry zarzadzajaca wszystkimi komponentami.
+class TratwaGame extends FlameGame with HasDraggables, HasTappables, HasKeyboardHandlerComponents {
+  late Raft raft;
+  late Minimap minimap;
+
+  @override
+  Future<void> onLoad() async {
+    await super.onLoad();
+    // Tlo oceanu i wyspa w centrum.
+    add(Ocean());
+    // Tratwa gracza
+    raft = Raft();
+    add(raft);
+    // Minimapa w lewym dolnym rogu
+    minimap = Minimap(raft: raft);
+    add(minimap);
+  }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    minimap.updatePlayerPosition(raft.position);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,7 @@
+import 'package:flame/game.dart';
+import 'package:flutter/widgets.dart';
+import 'game/tratwa_game.dart';
+
+void main() {
+  runApp(GameWidget(game: TratwaGame()));
+}

--- a/lib/ui/minimap.dart
+++ b/lib/ui/minimap.dart
@@ -1,0 +1,32 @@
+import 'package:flame/components.dart';
+import 'package:flame/palette.dart';
+import 'package:flutter/painting.dart';
+import '../world/raft.dart';
+import '../world/ocean.dart';
+
+/// Prosty komponent minimapy wyswietlany w lewym dolnym rogu ekranu.
+class Minimap extends PositionComponent {
+  final Raft raft;
+  final double scale;
+  Minimap({required this.raft, this.scale = 0.1}) {
+    position = Vector2.all(20);
+  }
+
+  @override
+  void render(Canvas canvas) {
+    super.render(canvas);
+    final paintBg = Paint()..color = const Color(0x88000000);
+    const double size = 100;
+    canvas.drawRect(Rect.fromLTWH(0, 0, size, size), paintBg);
+    // Wyspa w centrum
+    final center = Offset(size / 2, size / 2);
+    canvas.drawCircle(center, Ocean.islandRadius * scale, BasicPalette.green.paint());
+    // Pozycja tratwy
+    final player = center + Offset(raft.position.x * scale, raft.position.y * scale);
+    canvas.drawCircle(player, 2, BasicPalette.red.paint());
+  }
+
+  void updatePlayerPosition(Vector2 pos) {
+    // Metoda zachowana dla zgodnosci; aktualizacja wykonywana w render.
+  }
+}

--- a/lib/world/ocean.dart
+++ b/lib/world/ocean.dart
@@ -1,0 +1,19 @@
+import 'package:flame/components.dart';
+import 'package:flutter/painting.dart';
+
+/// Komponent odpowiedzialny za renderowanie oceanu i centralnej wyspy.
+class Ocean extends PositionComponent {
+  static const double mapRadius = 500;
+  static const double islandRadius = 50;
+
+  @override
+  void render(Canvas canvas) {
+    super.render(canvas);
+    final center = Vector2.zero();
+    final paintOcean = Paint()..color = const Color(0xFF0066CC);
+    canvas.drawCircle(center.toOffset(), mapRadius, paintOcean);
+
+    final paintIsland = Paint()..color = const Color(0xFF228B22);
+    canvas.drawCircle(center.toOffset(), islandRadius, paintIsland);
+  }
+}

--- a/lib/world/raft.dart
+++ b/lib/world/raft.dart
@@ -1,0 +1,55 @@
+import 'package:flame/components.dart';
+import 'package:flame/input.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/painting.dart';
+import 'ocean.dart';
+
+/// Komponent reprezentujacy tratwe gracza wraz z logika ruchu.
+class Raft extends PositionComponent with KeyboardHandler {
+  static const double speed = 150;
+  final Paint _paint = Paint()..color = const Color(0xFF964B00);
+  Vector2 velocity = Vector2.zero();
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    position += velocity * dt;
+    final double distance = position.length;
+    if (distance > Ocean.mapRadius) {
+      position = position.normalized() * Ocean.mapRadius;
+    }
+  }
+
+  @override
+  void render(Canvas canvas) {
+    super.render(canvas);
+    final rect = Rect.fromCenter(center: Offset.zero, width: 40, height: 40);
+    canvas.drawRect(rect, _paint);
+  }
+
+  @override
+  bool onKeyEvent(RawKeyEvent event, Set<LogicalKeyboardKey> keysPressed) {
+    velocity.setValues(0, 0);
+    if (keysPressed.contains(LogicalKeyboardKey.keyW) ||
+        keysPressed.contains(LogicalKeyboardKey.arrowUp)) {
+      velocity.y = -1;
+    }
+    if (keysPressed.contains(LogicalKeyboardKey.keyS) ||
+        keysPressed.contains(LogicalKeyboardKey.arrowDown)) {
+      velocity.y = 1;
+    }
+    if (keysPressed.contains(LogicalKeyboardKey.keyA) ||
+        keysPressed.contains(LogicalKeyboardKey.arrowLeft)) {
+      velocity.x = -1;
+    }
+    if (keysPressed.contains(LogicalKeyboardKey.keyD) ||
+        keysPressed.contains(LogicalKeyboardKey.arrowRight)) {
+      velocity.x = 1;
+    }
+    if (velocity.length2 > 0) {
+      velocity.normalize();
+      velocity *= speed;
+    }
+    return true;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,14 @@
+name: tratwa
+description: Prototyp gry mobilnej "Tratwa" w Flutter z użyciem Flame.
+version: 0.1.0
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flame: ^1.7.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter


### PR DESCRIPTION
## Podsumowanie
- Dodano szkielet projektu Flutter/Flame z klasą `TratwaGame`.
- Zaimplementowano komponenty oceanu, tratwy z ruchem w 8 kierunkach oraz minimapy.
- Uzupełniono dokumentację i plik `pubspec.yaml`.

## Testy
- `flutter pub get` *(niewykonane: brak zainstalowanego Fluttera)*
- `flutter test` *(niewykonane: brak zainstalowanego Fluttera)*

------
https://chatgpt.com/codex/tasks/task_e_6899973c524c8321980d7ffd8fb86601